### PR TITLE
mum.h: fix incorrect bswap macros

### DIFF
--- a/mum.h
+++ b/mum.h
@@ -126,12 +126,12 @@ static _MUM_INLINE uint64_t _mum (uint64_t v, uint64_t p) {
 }
 
 #if defined(_MSC_VER)
-#define _mum_bswap_32(x) _byteswap_uint32_t (x)
-#define _mum_bswap_64(x) _byteswap_uint64_t (x)
+#define _mum_bswap32(x) _byteswap_uint32_t (x)
+#define _mum_bswap64(x) _byteswap_uint64_t (x)
 #elif defined(__APPLE__)
 #include <libkern/OSByteOrder.h>
-#define _mum_bswap_32(x) OSSwapInt32 (x)
-#define _mum_bswap_64(x) OSSwapInt64 (x)
+#define _mum_bswap32(x) OSSwapInt32 (x)
+#define _mum_bswap64(x) OSSwapInt64 (x)
 #elif defined(__GNUC__)
 #define _mum_bswap32(x) __builtin_bswap32 (x)
 #define _mum_bswap64(x) __builtin_bswap64 (x)


### PR DESCRIPTION
@vnmakarov Current code fails on macOS since the header uses `_mum_bswap*` forms, but defines instead `_mum_bswap_*`.